### PR TITLE
fix: update goreleaser config to resolve deprecation warnings

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,25 +10,23 @@ before:
     - go mod tidy
 
 builds:
-  - env:
+  - id: wlhax
+    env:
       - CGO_ENABLED=0
     goos:
       - linux
 
 archives:
-  - format: tar.gz
-    # this name template makes the OS and Arch compatible with the results of `uname`.
-    name_template: >-
+  - name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-    # use zip for windows archives
-    format_overrides:
-      - goos: windows
-        format: zip
+    files:
+      - README.md
+      - LICENSE
 
 nfpms:
   # note that this is an array of nfpm configs
@@ -40,10 +38,6 @@ nfpms:
     # You can change the file name of the package.
     # Default: '{{ .PackageName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'.
     file_name_template: "{{ .ConventionalFileName }}"
-
-    # Build IDs for the builds you want to create NFPM packages for.
-    builds:
-      - wlhax
 
     vendor: dwapp.
     homepage: https://github.com/dwapp/wlhax
@@ -66,7 +60,7 @@ nfpms:
     bindir: /usr/bin
 
     # Default: extracted from `version` if it is semver compatible.
-    epoch: 2
+    epoch: "2"
 
     # Version Metadata (previously deb.metadata).
     # Setting metadata might interfere with version comparisons depending on the
@@ -76,7 +70,7 @@ nfpms:
     version_metadata: git
 
     # Version Release.
-    release: 1
+    release: "1"
 
     # Section.
     section: default

--- a/README.md
+++ b/README.md
@@ -16,16 +16,6 @@ Useful for debugging Wayland applications and protocols.
 - **Protocol object tracking**: Monitor globals, surfaces, seats, keyboards, pointers, and more
 - **Modern UI**: Built with pure [vaxis](https://git.sr.ht/~rockorager/vaxis) for fast terminal rendering
 
-## Recent Updates
-
-### v2.0 - Pure Vaxis UI Implementation
-
-- **Removed aerc dependency**: No longer depends on the aerc email client's UI components
-- **Pure vaxis implementation**: Built entirely with modern vaxis terminal UI library
-- **Simplified codebase**: Cleaner, more maintainable UI code
-- **Better performance**: Direct vaxis usage for improved rendering performance
-- **Custom UI components**: Implemented our own Grid, Tabs, Text, and TextInput components
-
 ## How to build
 
 ```bash

--- a/changelog.yml
+++ b/changelog.yml
@@ -1,3 +1,13 @@
+- semver: 2.0.0
+  date: 2025-09-11T19:45:00+08:00
+  packager: rewine <luhongxu@deepin.org>
+  changes:
+    - note: "Pure Vaxis UI Implementation - Removed aerc dependency, built entirely with modern vaxis terminal UI library"
+    - note: "Simplified codebase - Cleaner, more maintainable UI code with custom Grid, Tabs, Text, and TextInput components"
+    - note: "Better performance - Direct vaxis usage for improved rendering performance"
+    - note: "Removed shlex dependency - Replaced with standard library strings.Fields"
+    - note: "Updated all Go dependencies to latest versions including vaxis v0.15.0"
+    - note: "Fixed deprecated goreleaser configuration keys"
 - semver: 0.0.1
   date: 2025-01-14T20:23:50+08:00
   packager: rewine <luhongxu@deepin.org>

--- a/client.go
+++ b/client.go
@@ -4,8 +4,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/dwapp/wlhax/ui"
 	"git.sr.ht/~rockorager/vaxis"
+	"github.com/dwapp/wlhax/ui"
 )
 
 type ClientView struct {

--- a/clients.go
+++ b/clients.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/dwapp/wlhax/ui"
 	"git.sr.ht/~rockorager/vaxis"
+	"github.com/dwapp/wlhax/ui"
 )
 
 const (

--- a/dashboard.go
+++ b/dashboard.go
@@ -5,8 +5,8 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/dwapp/wlhax/ui"
 	"git.sr.ht/~rockorager/vaxis"
+	"github.com/dwapp/wlhax/ui"
 )
 
 type Dashboard struct {

--- a/exline.go
+++ b/exline.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/dwapp/wlhax/ui"
 	"git.sr.ht/~rockorager/vaxis"
+	"github.com/dwapp/wlhax/ui"
 )
 
 type ExLine struct {

--- a/ui.go
+++ b/ui.go
@@ -65,14 +65,14 @@ func (tv *TabView) PrevTab() {
 func (tv *TabView) Draw(win vaxis.Window) {
 	tv.win = win
 	width, height := win.Size()
-	
+
 	if height < 2 {
 		return
 	}
-	
+
 	// Draw tab bar
 	tv.drawTabBar(win.New(0, 0, width, 1))
-	
+
 	// Draw content
 	if tab := tv.Selected(); tab != nil {
 		contentWin := win.New(0, 1, width, height-1)
@@ -84,19 +84,19 @@ func (tv *TabView) Draw(win vaxis.Window) {
 func (tv *TabView) drawTabBar(win vaxis.Window) {
 	win.Clear()
 	width, _ := win.Size()
-	
+
 	col := 0
 	for i, tab := range tv.tabs {
 		style := vaxis.Style{}
 		if i == tv.selected {
 			style.Attribute = vaxis.AttrReverse
 		}
-		
+
 		tabName := " " + tab.Name + " "
 		if col+len(tabName) > width {
 			break
 		}
-		
+
 		// Print each character with style
 		for _, char := range []rune(tabName) {
 			win.SetCell(col, 0, vaxis.Cell{
@@ -120,12 +120,12 @@ func (tv *TabView) HandleEvent(ev vaxis.Event) bool {
 			return true
 		}
 	}
-	
+
 	// Pass event to current tab
 	if tab := tv.Selected(); tab != nil {
 		return tab.Content.HandleEvent(ev)
 	}
-	
+
 	return false
 }
 
@@ -160,10 +160,10 @@ func (ti *TextInput) Text() string {
 func (ti *TextInput) Draw(win vaxis.Window) {
 	win.Clear()
 	display := ti.prompt + ti.text
-	
+
 	// Print text using Segment
 	win.Print(vaxis.Segment{Text: display})
-	
+
 	// Show cursor position
 	cursorPos := len(ti.prompt) + ti.cursor
 	width, _ := win.Size()

--- a/ui/grid.go
+++ b/ui/grid.go
@@ -82,7 +82,7 @@ func (grid *Grid) Draw(ctx *Context) {
 		if cell.Row >= len(grid.rowLayout) || cell.Column >= len(grid.columnLayout) {
 			continue
 		}
-		
+
 		rows := grid.rowLayout[cell.Row : cell.Row+cell.RowSpan]
 		cols := grid.columnLayout[cell.Column : cell.Column+cell.ColSpan]
 		x := cols[0].Offset
@@ -122,7 +122,7 @@ func (grid *Grid) reflow(ctx *Context) {
 
 func (grid *Grid) computeLayout(specs []GridSpec, space int) []gridLayout {
 	layout := make([]gridLayout, len(specs))
-	
+
 	// First pass: exact sizes
 	remaining := space
 	for i, spec := range specs {
@@ -131,7 +131,7 @@ func (grid *Grid) computeLayout(specs []GridSpec, space int) []gridLayout {
 			remaining -= layout[i].Size
 		}
 	}
-	
+
 	// Second pass: weights
 	totalWeight := 0
 	for _, spec := range specs {
@@ -139,7 +139,7 @@ func (grid *Grid) computeLayout(specs []GridSpec, space int) []gridLayout {
 			totalWeight += spec.Size()
 		}
 	}
-	
+
 	if totalWeight > 0 && remaining > 0 {
 		for i, spec := range specs {
 			if spec.Strategy == SIZE_WEIGHT {
@@ -147,14 +147,14 @@ func (grid *Grid) computeLayout(specs []GridSpec, space int) []gridLayout {
 			}
 		}
 	}
-	
+
 	// Set offsets
 	offset := 0
 	for i := range layout {
 		layout[i].Offset = offset
 		offset += layout[i].Size
 	}
-	
+
 	return layout
 }
 

--- a/ui/stack.go
+++ b/ui/stack.go
@@ -20,7 +20,7 @@ func (stack *Stack) Pop() Drawable {
 	if len(stack.children) == 0 {
 		return nil
 	}
-	
+
 	d := stack.children[len(stack.children)-1]
 	stack.children = stack.children[:len(stack.children)-1]
 	return d
@@ -30,7 +30,7 @@ func (stack *Stack) Peek() Drawable {
 	if len(stack.children) == 0 {
 		return nil
 	}
-	
+
 	return stack.children[len(stack.children)-1]
 }
 

--- a/ui/tabs.go
+++ b/ui/tabs.go
@@ -102,7 +102,7 @@ func (tabs *Tabs) selectPriv(index int) {
 	if index < 0 || index >= len(tabs.tabs) {
 		return
 	}
-	
+
 	if tabs.curIndex != index {
 		tabs.pushHistory(tabs.curIndex)
 		tabs.curIndex = index
@@ -130,7 +130,7 @@ func (tabs *Tabs) pushHistory(index int) {
 	if index < 0 || index >= len(tabs.tabs) {
 		return
 	}
-	
+
 	for i, item := range tabs.history {
 		if item == index {
 			tabs.history = append(tabs.history[:i], tabs.history[i+1:]...)
@@ -157,18 +157,18 @@ func (strip *TabStrip) Draw(ctx *Context) {
 	for i, tab := range tabs.tabs {
 		name := tab.displayName()
 		width := runewidth.StringWidth(name) + 2 // padding
-		
+
 		style := vaxis.Style{}
 		if i == tabs.curIndex {
 			style.Attribute = vaxis.AttrReverse
 		}
-		
+
 		if x+width <= ctx.Width() {
 			ctx.Printf(x, 0, style, " %s ", name)
 			x += width
 		}
 	}
-	
+
 	// Fill remaining space
 	if x < ctx.Width() {
 		ctx.Fill(x, 0, ctx.Width()-x, 1, ' ', vaxis.Style{})

--- a/ui/textinput.go
+++ b/ui/textinput.go
@@ -71,14 +71,14 @@ func (ti *TextInput) deleteForward() {
 func (ti *TextInput) Draw(ctx *Context) {
 	ti.ctx = ctx
 	ctx.Fill(0, 0, ctx.Width(), ctx.Height(), ' ', ti.style)
-	
+
 	text := ti.prompt + string(ti.text)
 	if ti.password {
 		text = ti.prompt + strings.Repeat("*", len(ti.text))
 	}
-	
+
 	ctx.Printf(0, 0, ti.style, "%s", text)
-	
+
 	if ti.focus {
 		cursorPos := len([]rune(ti.prompt)) + ti.index
 		if cursorPos < ctx.Width() {
@@ -99,7 +99,7 @@ func (ti *TextInput) Event(event vaxis.Event) bool {
 	if !ti.focus {
 		return false
 	}
-	
+
 	if key, ok := event.(vaxis.Key); ok {
 		switch {
 		case key.Matches(vaxis.KeyBackspace):
@@ -126,15 +126,15 @@ func (ti *TextInput) Event(event vaxis.Event) bool {
 				}
 			}
 		}
-		
+
 		for _, change := range ti.change {
 			change(ti)
 		}
-		
+
 		ti.Invalidate()
 		return true
 	}
-	
+
 	return false
 }
 


### PR DESCRIPTION
- Remove deprecated archives.format property
- Remove deprecated archives.format_overrides.format property
- Remove deprecated nfpms.builds property
- Add explicit build ID for proper build referencing
- Fix YAML type issues (epoch and release as strings)
- Add files to include in archives (README.md, LICENSE)

All deprecation warnings resolved, goreleaser check now passes.